### PR TITLE
biicode support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ cmake_install.cmake
 /3rdparty/usr/
 /bin
 /tests/Testing
+/bii

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,26 @@ project(libappc CXX)
 set(CMAKE_CXX_FLAGS "-std=c++11 -Wall -Wextra -pedantic")
 set(CMAKE_CXX_FLAGS_DISTRIBUTION "-O3")
 
+######
+
+if(BIICODE)
+	ADD_BIICODE_TARGETS()
+
+	string(REPLACE " " ";" TARGET_CXX_FLAGS              ${CMAKE_CXX_FLAGS})
+	string(REPLACE " " ";" TARGET_CXX_FLAGS_DISTRIBUTION ${CMAKE_CXX_FLAGS_DISTRIBUTION})
+
+	target_include_directories(${BII_BLOCK_TARGET} INTERFACE src)
+	target_compile_options(${BII_BLOCK_TARGET} INTERFACE ${TARGET_CXX_FLAGS}
+		                   $<$<CONFIG:distribution>:${CMAKE_CXX_FLAGS_DISTRIBUTION}>)
+
+	find_library(LIB_ARCHIVE NAMES archive)
+	target_link_libraries(${BII_BLOCK_TARGET} INTERFACE ${LIB_ARCHIVE})
+
+	return()
+endif()
+
+######
+
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # libappc
 
 [![Build Status](https://travis-ci.org/cdaylward/libappc.svg?branch=master)](https://travis-ci.org/cdaylward/libappc)
+[![Build Status](https://webapi.biicode.com/v1/badges/manu343726/manu343726/libappc/master)](https://www.biicode.com/manu343726/libappc) 
 
 ## Overview
 
@@ -18,6 +19,11 @@ Requires libarchive, libcurl, and functional std::regex (If using gcc, >= 4.9)
 1. Bootstrap it (download and build dependencies): `./bootstrap.sh`
 2. Run the tests: `./test.sh`
 3. Build the examples: `./build.sh`
+
+### With [biicode](https://www.biicode.com)
+
+1. Run `bii buzz` command
+2. Run examples on `bin/` directory
 
 ## Status
 

--- a/biicode.conf
+++ b/biicode.conf
@@ -1,0 +1,18 @@
+
+[paths]
+	# Local directories to look for headers
+	# (bii needs to look on your sources to find deps automatically)
+	src/
+
+[includes]
+	# Map any curl include to biicode's curl block
+	curl/*.h: lasote/curl/include
+
+	# Map any gtest include to biicode's gtest block
+	gtest/*.h: google/gtest/include
+	
+[requirements]
+	 google/gtest: 10
+	 lasote/curl: 2
+[parent]
+	manu343726/libappc: 0


### PR DESCRIPTION
This PR adds support for the libappc library on [biicode](https://www.biicode.com) C/C++ dependency manager.

This contains three simple changes:
- _`CMakeLists.txt`_: biicode is file based, dependencies are managed on individual files, but those are usually shared/shipped as a _block_.  `manu343726/libappc` block in this case. A block, the libappc project in this case, has its own `CMakeLists.txt` file with build settings. So to support biicode you just have to take care of bii and its block targets in your existing CMakeLists.txt file. Ask me if you have any doubts about what bii does internally and what those targets mean.
- _`biicode.conf`_: This is the configuration file of the block. There are settings such as the specific versions on the dependencies the block has (libcurl and google test), and how your existing `#include`s are mapped to point to the bii blocks.
- _`REAMDME.md`_: Badge pointing to the biicode block, and _with biicode_ getting started entry.

The point of adding bii support is that you don't have to manage your third party deps manually through custom cmake scripts. Except libfile (We have no libfile block yet) both gtest and libcurl are managed by biicode automatically from your `#include` directives.
